### PR TITLE
implement the `start` lang item

### DIFF
--- a/examples/blink.rs
+++ b/examples/blink.rs
@@ -1,12 +1,10 @@
 #![no_std]
-#![no_main]
 
-#[macro_use]
 extern crate tock;
 
 use tock::{led, timer};
 
-tock_main!({
+fn main() {
     let led_count = led::count();
     loop {
         for i in 0..led_count {
@@ -14,5 +12,4 @@ tock_main!({
             timer::delay_ms(500);
         }
     }
-});
-
+}

--- a/layout.ld
+++ b/layout.ld
@@ -24,7 +24,7 @@ SECTIONS {
     .text :
     {
         _text = .;
-        KEEP (*(.start))
+        KEEP (*(.text._start))
         *(.text*)
         *(.rodata*)
 

--- a/src/lang_items.rs
+++ b/src/lang_items.rs
@@ -1,0 +1,36 @@
+/// Lang item required to make the normal `main` work in applications
+// This is how the `start` lang item works:
+// When `rustc` compiles a binary crate, it creates a `main` function that looks
+// like this:
+//
+// ```
+// #[export_name = "main"]
+// pub extern "C" fn rustc_main(argc: isize, argv: *const *const u8) -> isize {
+//     start(main)
+// }
+// ```
+//
+// Where `start` is this function and `main` is the binary crate's `main`
+// function.
+//
+// The final piece is that the entry point of our program, _start, has to call
+// `rustc_main`. That's covered by the `_start` function in the root of this
+// crate.
+#[lang = "start"]
+extern "C" fn start(
+    main: fn(),
+    _argc: isize,
+    _argv: *const *const u8,
+) -> isize {
+    main();
+
+    0
+}
+
+#[lang = "eh_personality"]
+extern "C" fn eh_personality() {}
+
+#[lang = "panic_fmt"]
+unsafe extern "C" fn rust_begin_unwind() {
+    loop {}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,29 +1,29 @@
-#![feature(asm,lang_items)]
+#![feature(asm, lang_items)]
 #![no_std]
 
 pub mod syscalls;
 pub mod timer;
 pub mod led;
 
-#[macro_export]
-macro_rules! tock_main {
-    ($init:expr) => {
-        #[no_mangle]
-        #[allow(unreachable_code)]
-        pub extern "C" fn _start() -> ! {
-            $init
-            loop {
-                ::tock::syscalls::yieldk();
-            }
-        }
-    }
-}
+mod lang_items;
 
-#[lang="eh_personality"]
-pub extern "C" fn eh_personality() {}
+use core::ptr;
 
-#[lang = "panic_fmt"]
+/// Tock programs' entry point
+#[doc(hidden)]
 #[no_mangle]
-pub unsafe extern "C" fn rust_begin_unwind() {
-    loop {}
+pub extern "C" fn _start() -> ! {
+    extern "C" {
+        // NOTE `rustc` forces this signature on us. See `src/lang_items.rs`
+        fn main(argc: isize, argv: *const *const u8) -> isize;
+    }
+
+    // arguments are not used in Tock applications
+    unsafe {
+        main(0, ptr::null());
+    }
+
+    loop {
+        ::syscalls::yieldk();
+    }
 }


### PR DESCRIPTION
this let us use the normal `main` function in applications instead of the
`tock_main!` macro.

the blink example has been updated and produces the exact same disassembly as
the old version when compiled in release mode

---

@alevy This is looking very neat. Just a `xargo build` and you get a Tock application. Great work 👍 