### PR TITLE
fixup license metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tock"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+license = "MIT/Apache-2.0"
 
 [dependencies]
 

--- a/README.md
+++ b/README.md
@@ -16,3 +16,21 @@ This project is nascent and still under heavy development, but first steps:
 3. Now you should be able to build with:
 
     `xargo build --target thumbv7em-tock-eabi`
+
+
+## License
+
+Licensed under either of
+
+ * Apache License, Version 2.0
+   ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license
+   ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.


### PR DESCRIPTION
Because apparently I lurk #rust-internals now and this was an issue
for some totally independent stuff but we may as well do it right

Following guidance from
https://github.com/brson/rust-api-guidelines#crate-and-its-dependencies-have-a-permissive-license-c-permissive