### PR TITLE
syscalls: mark asm clobbers correctly for yieldk

### DIFF
--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -1,7 +1,34 @@
 
 pub fn yieldk() {
+    // Note: A process stops yielding when there is a callback ready to run,
+    // which the kernel executes by modifying the stack frame pushed by the
+    // hardware. The kernel copies the PC value from the stack frame to the LR
+    // field, and sets the PC value to callback to run. When this frame is
+    // unstacked during the interrupt return, the effectively clobbers the LR
+    // register.
+    //
+    // At this point, the callback function is now executing, which may itself
+    // clobber any of the other caller-saved registers. Thus we mark this
+    // inline assembly as conservatively clobbering all caller-saved registers,
+    // forcing yield to save any live registers.
+    //
+    // Upon direct observation of this function, the LR is the only register
+    // that is live across the SVC invocation, however, if the yield call is
+    // inlined, it is possible that the LR won't be live at all (commonly seen
+    // for the `loop { yieldk(); }` idiom) or that other registers are live,
+    // thus it is important to let the compiler do the work here.
+    //
+    // According to the AAPCS: A subroutine must preserve the contents of the
+    // registers r4-r8, r10, r11 and SP (and r9 in PCS variants that designate
+    // r9 as v6) As our compilation flags mark r9 as the PIC base register, it
+    // does not need to be saved. Thus we must clobber r0-3, r12, and LR
     unsafe {
-        asm!("push {lr}\n svc 0\n pop {lr}" : : : "memory", "lr" : "volatile");
+        asm!(
+            "svc 0"
+            :
+            :
+            : "memory", "r0", "r1", "r2", "r3", "r12", "lr"
+            : "volatile");
     }
 }
 


### PR DESCRIPTION
This follows the same rationale and is the same clobber set as used
for the C `yield` implementation. This also removes the unneeded
push/pop of the lr.

---

Not yet tested on HW; that's the next step